### PR TITLE
Update docs to include signature options for signDataItem, batchSignDataItem and dispatch.

### DIFF
--- a/api/batch-sign-dataitem.md
+++ b/api/batch-sign-dataitem.md
@@ -6,12 +6,17 @@ description: Wander Injected API batchSignDataItem() function
 
 The batchSignDataItem() function allows you to create and sign an array of data item objects, compatible with [`arbundles`](https://www.npmjs.com/package/@dha-team/arbundles). These data items can then be submitted to an [ANS-104](https://github.com/ArweaveTeam/arweave-standards/blob/master/ans/ANS-104.md) compatible bundler.
 
-| Argument    | Type                                             | Description                    |
-| ----------- | ------------------------------------------------ | ------------------------------ |
-| `dataItems` | [`DataItem[]`](batch-sign-dataitem.md#data-item) | An array of data items to sign |
+| Argument    | Type                                                                                                                     | Description                           |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| `dataItems` | [`DataItem[]`](batch-sign-dataitem.md#data-item)                                                                         | An array of data items to sign        |
+| `options?`  | [`SignatureOptions`](https://github.com/ArweaveTeam/arweave-js/blob/master/src/common/lib/crypto/crypto-interface.ts#L3) | Arweave transaction signature options |
 
 {% hint style="info" %}
 **Note:** This function requires the [`SIGN_TRANSACTION`](connect.md#permissions) permission.
+{% endhint %}
+
+{% hint style="info" %}
+**Note:** The `options` argument is optional, if it is not provided, the extension will use the default signature options (default salt length) to sign the transaction.
 {% endhint %}
 
 {% hint style="warning" %}

--- a/api/dispatch.md
+++ b/api/dispatch.md
@@ -6,12 +6,17 @@ description: Wander Injected API dispatch() function
 
 The `dispatch()` function allows you to quickly sign and send a transaction to the network in a bundled format. It is best for smaller datas and contract interactions. If the bundled transaction cannot be submitted, it will fall back to a base layer transaction. The function returns the [result](dispatch.md#dispatch-result) of the API call.
 
-| Argument      | Type                                                                    | Description                                                  |
-| ------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `transaction` | [`Transaction`](https://github.com/arweaveTeam/arweave-js#transactions) | A valid Arweave transaction instance (**without a keyfile**) |
+| Argument      | Type                                                                                                                     | Description                                                  |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `transaction` | [`Transaction`](https://github.com/arweaveTeam/arweave-js#transactions)                                                  | A valid Arweave transaction instance (**without a keyfile**) |
+| `options?`    | [`SignatureOptions`](https://github.com/ArweaveTeam/arweave-js/blob/master/src/common/lib/crypto/crypto-interface.ts#L3) | Arweave transaction signature options                        |
 
 {% hint style="info" %}
 **Note:** This function requires the [`DISPATCH`](connect.md#permissions) permission.
+{% endhint %}
+
+{% hint style="info" %}
+**Note:** The `options` argument is optional, if it is not provided, the extension will use the default signature options (default salt length) to sign the transaction.
 {% endhint %}
 
 {% hint style="warning" %}

--- a/api/sign-dataitem.md
+++ b/api/sign-dataitem.md
@@ -6,12 +6,17 @@ description: Wander Injected API signDataItem() function
 
 The signDataItem() function allows you to create and sign a data item object, compatible with [`arbundles`](https://www.npmjs.com/package/@dha-team/arbundles). These data items can then be submitted to an [ANS-104](https://github.com/ArweaveTeam/arweave-standards/blob/master/ans/ANS-104.md) compatible bundler.
 
-| Argument   | Type                                     | Description                   |
-| ---------- | ---------------------------------------- | ----------------------------- |
-| `dataItem` | [`DataItem`](sign-dataitem.md#data-item) | The bundled data item to sign |
+| Argument   | Type                                                                                                                     | Description                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| `dataItem` | [`DataItem`](sign-dataitem.md#data-item)                                                                                 | The bundled data item to sign         |
+| `options?` | [`SignatureOptions`](https://github.com/ArweaveTeam/arweave-js/blob/master/src/common/lib/crypto/crypto-interface.ts#L3) | Arweave transaction signature options |
 
 {% hint style="info" %}
 **Note:** This function requires the [`SIGN_TRANSACTION`](connect.md#permissions) permission.
+{% endhint %}
+
+{% hint style="info" %}
+**Note:** The `options` argument is optional, if it is not provided, the extension will use the default signature options (default salt length) to sign the transaction.
 {% endhint %}
 
 {% hint style="warning" %}


### PR DESCRIPTION
Update the docs for `signDateItem()`, `batchSignDataItem()` and `dispatch()` to include the signature options, as implemented in https://github.com/wanderwallet/Wander/pull/775.