### PR TITLE
refactor: update tier info api

### DIFF
--- a/api/get-wander-tier-info.md
+++ b/api/get-wander-tier-info.md
@@ -105,7 +105,7 @@ function isValidTierInfo(data: WanderTierInfoFromApi): data is WanderTierInfoFro
 async function getWanderTierInfo(walletAddress: string): Promise<WanderTierInfo> {
   let data: WanderTierInfoFromApi;
   try {
-    const response = await fetch(`https://wander-cache-ruddy.vercel.app/api/tier-info?address=${walletAddress}`);
+    const response = await fetch(`https://cache.wander.app/api/tier-info?address=${walletAddress}`);
     if (!response.ok) {
       throw new Error("Failed to fetch tier info from cache API");
     }
@@ -184,7 +184,7 @@ async function getBatchWanderTierInfo(walletAddresses: string[]): Promise<Record
   let data: Record<string, WanderTierInfoFromApi>;
 
   try {
-    const response = await fetch(`https://wander-cache-ruddy.vercel.app/api/tier-info?addresses=${walletAddresses.join(",")}`);
+    const response = await fetch(`https://cache.wander.app/api/tier-info?addresses=${walletAddresses.join(",")}`);
     if (!response.ok) {
       throw new Error("Failed to fetch tier info from cache API");
     }


### PR DESCRIPTION
## Summary

This PR updates the tier info api to use cache API as primary source for fetching the tier info for wallet addresses.